### PR TITLE
Handle overload for HttpStatus codes and exception handling for large json payloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver</artifactId>
+			<version>3.6.4</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
+++ b/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
@@ -18,6 +18,7 @@ public class AbstractMessageHelper {
 	public static final String CONST_CAUSE = "cause";
 	public static final String CONST_REASON = "reason";
 	public static final String CONST_TRACE = "trace";
+	public static final String CONST_MESSAGE = "message";
 
 	public static void append(Map<String, Object> log, Exception e) {
 		log.put(AbstractMessageHelper.CONST_SUCCESS, false);

--- a/src/main/java/gov/cdc/helper/ErrorHandler.java
+++ b/src/main/java/gov/cdc/helper/ErrorHandler.java
@@ -2,19 +2,15 @@ package gov.cdc.helper;
 
 import java.util.Map;
 
-import gov.cdc.foundation.helper.MessageHelper;
 import org.apache.log4j.Logger;
 import org.bson.BsonSerializationException;
 import org.json.JSONObject;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import gov.cdc.helper.common.ServiceException;
-import sun.plugin2.message.Message;
 
 @Configuration
 public class ErrorHandler {
@@ -24,7 +20,7 @@ public class ErrorHandler {
 	private static ErrorHandler me = null;
 
 	public ResponseEntity<?> handle(HttpStatus status, Map<String,Object> log){
-			log.put(MessageHelper.CONST_SUCCESS, false);
+			log.put(AbstractMessageHelper.CONST_SUCCESS, false);
 			ObjectMapper mapper = new ObjectMapper();
 			JsonNode error = null;
 			try{
@@ -51,8 +47,8 @@ public class ErrorHandler {
 			log.put("cause", se.getObj());
 		}
 		
-		log.put(MessageHelper.CONST_SUCCESS, false);
-		log.put(MessageHelper.CONST_MESSAGE, e.getMessage());
+		log.put(AbstractMessageHelper.CONST_SUCCESS, false);
+		log.put(AbstractMessageHelper.CONST_MESSAGE, e.getMessage());
 
 		ObjectMapper mapper = new ObjectMapper();
 		JsonNode error = null;

--- a/src/main/java/gov/cdc/helper/ObjectHelper.java
+++ b/src/main/java/gov/cdc/helper/ObjectHelper.java
@@ -244,7 +244,7 @@ public class ObjectHelper extends AbstractHelper {
 		else
 			url = url.replace("size={size}", "");
 
-		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executePost(url);
+		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executeGet(url);
 		return new JSONObject(response.getBody());
 	}
 


### PR DESCRIPTION
Method added to ErrorHandler for receiving a status code and map of log messages instead of an exception and map of log messages.  
Method should help streamline providing more accurate status codes in our microservices.

mongodb-driver added to pom for BsonSerializationException.

BsonSerializationException check added to the original handle method to properly return 413 instead of 400 when json payload is too large.