### PR TITLE
added maven javadoc plugin. Build javadoc with mvn install

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.cdc</groupId>
 	<artifactId>fdns-java-sdk</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.6</version>
 	<packaging>jar</packaging>
 	
 	<name>FDNS Java SDK</name>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,22 @@
 					</environmentVariables>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<doclint>none</doclint>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/src/main/java/gov/cdc/helper/AbstractHelper.java
+++ b/src/main/java/gov/cdc/helper/AbstractHelper.java
@@ -12,10 +12,16 @@ public class AbstractHelper {
 		this.authorizationHeader = authorizationHeader;
 		return this;
 	}
-	
+
+	/**
+	 * Returns <code>true</code> if authorization header starts with 'bearer' or 'basic'.
+	 *
+	 * @return <code>true</code> if authorization header starts with 'bearer' or 'basic';
+	 *         <code>false</code> otherwise
+	 */
 	public boolean isValidAuthorizationHeader() {
 		return authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer") || authorizationHeader.startsWith("basic") || authorizationHeader.startsWith("Basic"));
 	}
-	
-	
+
+
 }

--- a/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
+++ b/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
@@ -22,8 +22,9 @@ public class AbstractMessageHelper {
 
 
 	/**
-	 * Appends Appends exception information to log
-	 * @param log the map with which to store exception details
+	 * Appends exception information to specified map
+	 *
+	 * @param log stores exception details
 	 * @param e exception to be stored in log
 	 */
 	public static void append(Map<String, Object> log, Exception e) {

--- a/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
+++ b/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
@@ -22,9 +22,9 @@ public class AbstractMessageHelper {
 
 
 	/**
-	 *
-	 * @param log
-	 * @param e
+	 * Appends Appends exception information to log
+	 * @param log the map with which to store exception details
+	 * @param e exception to be stored in log
 	 */
 	public static void append(Map<String, Object> log, Exception e) {
 		log.put(AbstractMessageHelper.CONST_SUCCESS, false);

--- a/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
+++ b/src/main/java/gov/cdc/helper/AbstractMessageHelper.java
@@ -20,6 +20,12 @@ public class AbstractMessageHelper {
 	public static final String CONST_TRACE = "trace";
 	public static final String CONST_MESSAGE = "message";
 
+
+	/**
+	 *
+	 * @param log
+	 * @param e
+	 */
 	public static void append(Map<String, Object> log, Exception e) {
 		log.put(AbstractMessageHelper.CONST_SUCCESS, false);
 		log.put(AbstractMessageHelper.CONST_ERROR, e.getMessage());

--- a/src/main/java/gov/cdc/helper/CDAHelper.java
+++ b/src/main/java/gov/cdc/helper/CDAHelper.java
@@ -10,7 +10,16 @@ public class CDAHelper extends AbstractHelper {
 
 	private static String CDA_SERVER_URL;
 	private static String PARSE_CDA;
-	
+
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of CDAHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of CDAHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static CDAHelper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (CDAHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -18,13 +27,18 @@ public class CDAHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * CDAHelper singleton constructor
+	 * @return
+	 * @throws IOException
+	 */
 	public static CDAHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
 		}
 		return instance;
 	}
-	
+
 	private static CDAHelper createNew() throws IOException {
 		CDAHelper helper = new CDAHelper();
 
@@ -35,7 +49,13 @@ public class CDAHelper extends AbstractHelper {
 		
 		return helper;
 	}
-	
+
+	/**
+	 * Send provided CDA message to CDA Utils and return parsed message as JSONObject
+	 *
+	 * @param cda_message message to be parsed
+	 * @return parsed cda message
+	 */
 	public JSONObject parse(String cda_message) {
 		String url = CDA_SERVER_URL + PARSE_CDA;
 

--- a/src/main/java/gov/cdc/helper/CDAHelper.java
+++ b/src/main/java/gov/cdc/helper/CDAHelper.java
@@ -13,7 +13,7 @@ public class CDAHelper extends AbstractHelper {
 
 	/**
 	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
-	 * constructs new instance of CDAHelper class and sets the authorization header to the provided value.
+	 * constructs new instance of CDAHelper class and sets the authorization header to the specified value.
 	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of CDAHelper.
 	 *
 	 * @param authorizationHeader
@@ -51,7 +51,7 @@ public class CDAHelper extends AbstractHelper {
 	}
 
 	/**
-	 * Send provided CDA message to CDA Utils and return parsed message as JSONObject
+	 * Send specified CDA message to CDA Utils and return parsed message as JSONObject
 	 *
 	 * @param cda_message message to be parsed
 	 * @return parsed cda message

--- a/src/main/java/gov/cdc/helper/CombinerHelper.java
+++ b/src/main/java/gov/cdc/helper/CombinerHelper.java
@@ -22,6 +22,15 @@ public class CombinerHelper extends AbstractHelper {
 	private static String DELETE_CONFIG_PATH;
 	private static String CREATE_OR_UPDATE_CONFIG_PATH;
 
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of CombinerHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of combinerHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static CombinerHelper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (CombinerHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -29,6 +38,11 @@ public class CombinerHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * CombinerHelper singleton constructor
+	 * @return
+	 * @throws IOException
+	 */
 	public static CombinerHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -50,6 +64,13 @@ public class CombinerHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Execute post call to combiner to flatten provided json object to json, csv, or xlsx
+	 *
+	 * @param targetType target file type (json, csv, or xlsx)
+	 * @param json json object to flatten
+	 * @return flattened transformation of provided JSONObject in format specified in targetType
+	 */
 	public byte[] flatten(String targetType, JSONObject json) {
 		String url = COMBINER_SERVER_URL + FLATTEN_PATH;
 		url = url.replace("{targetType}", targetType);
@@ -69,6 +90,17 @@ public class CombinerHelper extends AbstractHelper {
 		return response.getBody().getBytes();
 	}
 
+	/**
+	 *
+	 * Execute post call to combiner to transform provided json objects into specified targetType
+	 *
+	 * @param targetType target file type (csv or xlsx)
+	 * @param configName name of config combiner should reference for transformation
+	 * @param jsons list of objects containing data to be transformed
+	 * @param orientation
+	 * @param includeHeader
+	 * @return transformed file(s) in format specified in targetType
+	 */
 	public byte[] combine(String targetType, String configName, List<JSONObject> jsons, String orientation, boolean includeHeader) {
 		String url = COMBINER_SERVER_URL + COMBINE_PATH;
 		url = url.replace("{targetType}", targetType);
@@ -98,6 +130,12 @@ public class CombinerHelper extends AbstractHelper {
 		return response.getBody().getBytes();
 	}
 
+	/**
+	 * Execute post call to combiner to create or update configuration
+	 * @param configName name of config to create or update
+	 * @param config new config data
+	 * @return response from combiner
+	 */
 	public JSONObject createOrUpdateConfig(String configName, JSONObject config) {
 		String url = COMBINER_SERVER_URL + CREATE_OR_UPDATE_CONFIG_PATH;
 		url = url.replace("{configName}", configName);
@@ -106,6 +144,11 @@ public class CombinerHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Execute post call to combiner to delete configuration
+	 * @param configName name of config to delete
+	 * @return response from combiner
+	 */
 	public JSONObject deleteConfig(String configName) {
 		String url = COMBINER_SERVER_URL + DELETE_CONFIG_PATH;
 		url = url.replace("{configName}", configName);

--- a/src/main/java/gov/cdc/helper/CombinerHelper.java
+++ b/src/main/java/gov/cdc/helper/CombinerHelper.java
@@ -24,7 +24,7 @@ public class CombinerHelper extends AbstractHelper {
 
 	/**
 	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
-	 * constructs new instance of CombinerHelper class and sets the authorization header to the provided value.
+	 * constructs new instance of CombinerHelper class and sets the authorization header to the specified value.
 	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of combinerHelper.
 	 *
 	 * @param authorizationHeader
@@ -97,8 +97,8 @@ public class CombinerHelper extends AbstractHelper {
 	 * @param targetType target file type (csv or xlsx)
 	 * @param configName name of config combiner should reference for transformation
 	 * @param jsons list of objects containing data to be transformed
-	 * @param orientation
-	 * @param includeHeader
+	 * @param orientation portrait or landscape
+	 * @param includeHeader whether or not to include header
 	 * @return transformed file(s) in format specified in targetType
 	 */
 	public byte[] combine(String targetType, String configName, List<JSONObject> jsons, String orientation, boolean includeHeader) {
@@ -132,6 +132,7 @@ public class CombinerHelper extends AbstractHelper {
 
 	/**
 	 * Execute post call to combiner to create or update configuration
+	 *
 	 * @param configName name of config to create or update
 	 * @param config new config data
 	 * @return response from combiner

--- a/src/main/java/gov/cdc/helper/DatabaseHelper.java
+++ b/src/main/java/gov/cdc/helper/DatabaseHelper.java
@@ -16,6 +16,14 @@ public class DatabaseHelper {
 	private static String dbUsername;
 	private static String dbPassword;
 
+	/**
+	 * DatabaseHelper constructor
+	 *
+	 * @param dbUrlOpt database url
+	 * @param dbTableOpt table name
+	 * @param dbUsernameOpt username
+	 * @param dbPasswordOpt password
+	 */
 	public DatabaseHelper(String dbUrlOpt, String dbTableOpt, String dbUsernameOpt, String dbPasswordOpt) {
 		dbUrl = dbUrlOpt;
 		dbTable = dbTableOpt;
@@ -25,6 +33,13 @@ public class DatabaseHelper {
 
 	private static final Logger logger = Logger.getLogger(DatabaseHelper.class);
 
+	/**
+	 * Insert row into database
+	 *
+	 * @param data field and value pairs
+	 * @param fileData file data to be written as blob
+	 * @throws SQLException
+	 */
 	public void insert(Map<String, String> data, byte[] fileData) throws SQLException {
 		Connection conn = null;
 		PreparedStatement pstmt = null;

--- a/src/main/java/gov/cdc/helper/ErrorHandler.java
+++ b/src/main/java/gov/cdc/helper/ErrorHandler.java
@@ -39,10 +39,10 @@ public class ErrorHandler {
 	}
 
 	/**
-	 * Generate http 404 (Bad Request) or 413 (Payload Too Large) response for provided exception and log data
+	 * Generate http 404 (Bad Request) or 413 (Payload Too Large) response for specified exception and log data
 	 *
 	 * @param e exception to be returned with response
-	 * @param log log data to include in response
+	 * @param log details to include in response
 	 * @return http response with provided exception details and log data
 	 */
 	public ResponseEntity<?> handle(Exception e, Map<String, Object> log) {

--- a/src/main/java/gov/cdc/helper/ErrorHandler.java
+++ b/src/main/java/gov/cdc/helper/ErrorHandler.java
@@ -19,6 +19,13 @@ public class ErrorHandler {
 
 	private static ErrorHandler me = null;
 
+	/**
+	 *  Generate http error response for provided status and log data
+	 *
+	 * @param status http status code
+	 * @param log log data to provide in response
+	 * @return http response with provided code and log data
+	 */
 	public ResponseEntity<?> handle(HttpStatus status, Map<String,Object> log){
 			log.put(AbstractMessageHelper.CONST_SUCCESS, false);
 			ObjectMapper mapper = new ObjectMapper();
@@ -31,6 +38,13 @@ public class ErrorHandler {
 		return ResponseEntity.status(status).body(error);
 	}
 
+	/**
+	 * Generate http 404 (Bad Request) or 413 (Payload Too Large) response for provided exception and log data
+	 *
+	 * @param e exception to be returned with response
+	 * @param log log data to include in response
+	 * @return http response with provided exception details and log data
+	 */
 	public ResponseEntity<?> handle(Exception e, Map<String, Object> log) {
 		boolean trace = false;
 		try {
@@ -65,6 +79,11 @@ public class ErrorHandler {
 		}
 	}
 
+	/**
+	 * ErrorHandler singleton constructor
+	 *
+	 * @return
+	 */
 	public static ErrorHandler getInstance() {
 		if (me == null)
 			me = new ErrorHandler();

--- a/src/main/java/gov/cdc/helper/HL7Helper.java
+++ b/src/main/java/gov/cdc/helper/HL7Helper.java
@@ -26,6 +26,15 @@ public class HL7Helper extends AbstractHelper {
 	private static String VALIDATE_WITH_RULES_PATH;
 	private static String HL7_SPEC;
 
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of HL7Helper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of HL7Helper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static HL7Helper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (HL7Helper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -33,6 +42,12 @@ public class HL7Helper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * HL7Helper singleton constructor
+	 *
+	 * @return
+	 * @throws IOException
+	 */
 	public static HL7Helper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -58,6 +73,15 @@ public class HL7Helper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Execute post call to HL7 Utils to transform an HL7 message to XML document.
+	 *
+	 * @param hl7_message  HL7 message to transform
+	 * @return XML transformation of hl7_message
+	 * @throws ParserConfigurationException
+	 * @throws SAXException
+	 * @throws IOException
+	 */
 	public Document parseToXML(String hl7_message) throws ParserConfigurationException, SAXException, IOException {
 		String url = HL7_SERVER_URL + PARSE_HL7_TO_XML_PATH;
 
@@ -68,10 +92,24 @@ public class HL7Helper extends AbstractHelper {
 		return dBuilder.parse(new ByteArrayInputStream(response.getBody().getBytes()));
 	}
 
+	/**
+	 * Calls HL7 Utils to transform HL7 to JSON with spec defined in config-services.properties
+	 * @see HL7Helper#parse(String, String)
+	 *
+	 * @param hl7_message message to parse
+	 * @return
+	 */
 	public JSONObject parse(String hl7_message) {
 		return parse(hl7_message, HL7_SPEC);
 	}
 
+	/**
+	 * Execute post call to HL7 Utils to transform HL7 to JSON.
+	 *
+	 * @param hl7_message hl7 message to transform to json
+	 * @param spec  hl7 or phinms
+	 * @return json transformation of hl7 message
+	 */
 	public JSONObject parse(String hl7_message, String spec) {
 		String url = HL7_SERVER_URL + PARSE_HL7_PATH;
 		url = url.replace("{spec}", spec);
@@ -80,6 +118,14 @@ public class HL7Helper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Execute post call to HL7 Utils to transform HL7 to JSON.
+	 *
+	 * @param hl7_message hl7 message to transform to json
+	 * @param spec hl7 or phinms
+	 * @param profile 	message profile
+	 * @return json transformation of hl7 message
+	 */
 	public JSONObject parse(String hl7_message, String spec, String profile) {
 		String url = HL7_SERVER_URL + PARSE_HL7_PROFILE_PATH;
 		url = url.replace("{spec}", spec);
@@ -89,10 +135,24 @@ public class HL7Helper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Calls HL7 Utils to get case identifiers for HL7 message with spec defined in config-services.properties
+	 * @see HL7Helper#getCaseId(String, String)
+	 *
+	 * @param hl7_message message from which to read case identifiers
+	 * @return case identifier segments
+	 */
 	public JSONObject getCaseId(String hl7_message) {
 		return getCaseId(hl7_message, HL7_SPEC);
 	}
 
+	/**
+	 * Execute post call to HL7 Utils to get case identifiers from hl7 message
+	 *
+	 * @param hl7_message message containing Case Ids
+	 * @param spec hl7 or phinms
+	 * @return case identifier segments
+	 */
 	public JSONObject getCaseId(String hl7_message, String spec) {
 		String url = HL7_SERVER_URL + GET_CASE_ID_PATH;
 		url = url.replace("{spec}", spec);
@@ -101,6 +161,12 @@ public class HL7Helper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Execute post call to HL7 Utils to get hash for hl7 message
+	 *
+	 * @param hl7_message message for which to get hash
+	 * @return hash value for message
+	 */
 	public JSONObject getMessageHash(String hl7_message) {
 		String url = HL7_SERVER_URL + GET_MESSAGE_HASH_PATH;
 

--- a/src/main/java/gov/cdc/helper/HL7Helper.java
+++ b/src/main/java/gov/cdc/helper/HL7Helper.java
@@ -28,7 +28,7 @@ public class HL7Helper extends AbstractHelper {
 
 	/**
 	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
-	 * constructs new instance of HL7Helper class and sets the authorization header to the provided value.
+	 * constructs new instance of HL7Helper class and sets the authorization header to the specified value.
 	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of HL7Helper.
 	 *
 	 * @param authorizationHeader

--- a/src/main/java/gov/cdc/helper/HL7Helper.java
+++ b/src/main/java/gov/cdc/helper/HL7Helper.java
@@ -97,7 +97,7 @@ public class HL7Helper extends AbstractHelper {
 	 * @see HL7Helper#parse(String, String)
 	 *
 	 * @param hl7_message message to parse
-	 * @return
+	 * @return json transformation
 	 */
 	public JSONObject parse(String hl7_message) {
 		return parse(hl7_message, HL7_SPEC);

--- a/src/main/java/gov/cdc/helper/IndexingHelper.java
+++ b/src/main/java/gov/cdc/helper/IndexingHelper.java
@@ -23,6 +23,15 @@ public class IndexingHelper extends AbstractHelper {
 	private static String DELETE_CONFIG_PATH;
 	private static String CREATE_OR_UPDATE_CONFIG_PATH;
 
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of IndexingHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of IndexingHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static IndexingHelper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (IndexingHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -30,6 +39,12 @@ public class IndexingHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * IndexingHelper singleton constructor
+	 *
+	 * @return
+	 * @throws IOException
+	 */
 	public static IndexingHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();

--- a/src/main/java/gov/cdc/helper/IndexingHelper.java
+++ b/src/main/java/gov/cdc/helper/IndexingHelper.java
@@ -73,10 +73,23 @@ public class IndexingHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Call Indexing Service to create index using type defined in config-services.properties
+	 *
+	 * @see IndexingHelper#createIndex(String)
+	 *
+	 * @return response from indexing service
+	 */
 	public JSONObject createIndex() {
 		return createIndex(TYPE);
 	}
 
+	/**
+	 * Call Indexing Service to create index for specified config
+	 *
+	 * @param type config to create index for
+	 * @return response from indexing service
+	 */
 	public JSONObject createIndex(String type) {
 		String url = INDEXING_SERVER_URL + CREATE_INDEX_PATH;
 		url = url.replace("{type}", type);
@@ -85,10 +98,23 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to delete index using type defined in config-services.properties
+	 *
+	 * @see IndexingHelper#deleteIndex(String)
+	 *
+	 * @return response from indexing service
+	 */
 	public JSONObject deleteIndex() {
 		return deleteIndex(TYPE);
 	}
 
+	/**
+	 * Call Indexing Service to delete index for specified config
+	 *
+	 * @param type config to delete index for
+	 * @return response from indexing service
+	 */
 	public JSONObject deleteIndex(String type) {
 		String url = INDEXING_SERVER_URL + DELETE_INDEX_PATH;
 		url = url.replace("{type}", type);
@@ -97,10 +123,25 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to index existing stored object using type(config) defined in config-service.properties
+	 *
+	 * @see IndexingHelper#indexObject(String, String)
+	 *
+	 * @param objectId id of object to index
+	 * @return response from indexing service
+	 */
 	public JSONObject indexObject(String objectId) {
 		return indexObject(TYPE, objectId);
 	}
 
+	/**
+	 * Call Indexing Service to index existing stored object
+	 *
+	 * @param type config name
+	 * @param objectId id of object to index
+	 * @return response from indexing service
+	 */
 	public JSONObject indexObject(String type, String objectId) {
 		String url = INDEXING_SERVER_URL + INDEX_OBJECT_PATH;
 		url = url.replace("{type}", type);
@@ -110,6 +151,14 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+
+	/**
+	 * Call Indexing Service to index a list of objects
+	 *
+	 * @param type config name
+	 * @param objectIds ids of objects to index
+	 * @return response from indexing service
+	 */
 	public JSONObject indexBulkObjects(String type, JSONArray objectIds) {
 		String url = INDEXING_SERVER_URL + INDEX_BULK_OBJECTS_PATH;
 		url = url.replace("{type}", type);
@@ -118,10 +167,25 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to get an indexed object using type(config) defined in config-service.properties
+	 *
+	 * @see IndexingHelper#getIndex(String, String)
+	 *
+	 * @param objectId id of object
+	 * @return response from indexing service
+	 */
 	public JSONObject getIndex(String objectId) {
 		return getIndex(TYPE, objectId);
 	}
 
+	/**
+	 * Call Indexing Service to get an indexed object
+	 *
+	 * @param type config name
+	 * @param objectId id of object
+	 * @return response from indexing service
+	 */
 	public JSONObject getIndex(String type, String objectId) {
 		String url = INDEXING_SERVER_URL + GET_INDEX_PATH;
 		url = url.replace("{type}", type);
@@ -131,10 +195,31 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to search indexed object
+	 *
+	 * @param type config name
+	 * @param query search query
+	 * @param hydrate whether or not to replace elastic search source with mongo document
+	 * @param from query start position
+	 * @param size number of results
+	 * @return response from indexing service
+	 */
 	public JSONObject search(String type, String query, boolean hydrate, int from, int size) {
 		return search(type, query, hydrate, from, size, null);
 	}
 
+	/**
+	 * Call Indexing Service to search indexed object
+	 *
+	 * @param type config name
+	 * @param query search query
+	 * @param hydrate whether or not to replace elastic search source with mongo document
+	 * @param from query start position
+	 * @param size number of results
+	 * @param scroll scroll live time (ex: 1m)
+	 * @return response from indexing service
+	 */
 	public JSONObject search(String type, String query, boolean hydrate, int from, int size, String scroll) {
 		String url = INDEXING_SERVER_URL + SEARCH_PATH;
 		url = url.replace("{type}", type);
@@ -151,6 +236,15 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to get scroll search result
+	 *
+	 * @param type config name
+	 * @param scroll scroll live time (ex: 1m)
+	 * @param scrollId scroll identifier
+	 * @param hydrate whether or not to replace elastic search source with mongo document
+	 * @return response from indexing service
+	 */
 	public JSONObject scroll(String type, String scroll, String scrollId, boolean hydrate) {
 		String url = INDEXING_SERVER_URL + SCROLL_PATH;
 		url = url.replace("{type}", type);
@@ -162,6 +256,12 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to delete scroll index
+	 *
+	 * @param scrollId scroll identifier
+	 * @return response from indexing service
+	 */
 	public JSONObject deleteScrollIndex(String scrollId) {
 		String url = INDEXING_SERVER_URL + DELETE_SCROLL_INDEX_PATH;
 		url = url.replace("{scrollId}", scrollId);
@@ -170,6 +270,13 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to create or update configuration
+	 *
+	 * @param configName configuration name
+	 * @param config new configuration
+	 * @return response from indexing service
+	 */
 	public JSONObject createOrUpdateConfig(String configName, JSONObject config) {
 		String url = INDEXING_SERVER_URL + CREATE_OR_UPDATE_CONFIG_PATH;
 		url = url.replace("{configName}", configName);
@@ -178,6 +285,12 @@ public class IndexingHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Indexing Service to delete configuration
+	 *
+	 * @param configName configuration name
+	 * @return response from indexing service
+	 */
 	public JSONObject deleteConfig(String configName) {
 		String url = INDEXING_SERVER_URL + DELETE_CONFIG_PATH;
 		url = url.replace("{configName}", configName);

--- a/src/main/java/gov/cdc/helper/MicrosoftHelper.java
+++ b/src/main/java/gov/cdc/helper/MicrosoftHelper.java
@@ -16,6 +16,15 @@ public class MicrosoftHelper extends AbstractHelper {
 	private static String XLSX_CONVERT_CSV_PATH;
 	private static String DOCX_EXTRACT_PATH;
 
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of MicrosoftHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of MicrosoftHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static MicrosoftHelper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (MicrosoftHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -23,6 +32,12 @@ public class MicrosoftHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * MicrosoftHelper singleton constructor
+	 *
+	 * @return
+	 * @throws IOException
+	 */
 	public static MicrosoftHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -45,12 +60,30 @@ public class MicrosoftHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Call Microsoft Utilities Service to get list of sheets of a xlsx file.
+	 *
+	 * @param filename expected filename
+	 * @param data xlsx file
+	 * @return response from msft utilities service with sheet names and indexes
+	 */
 	public JSONObject getSheets(String filename, byte[] data) {
 		String url = MICROSOFT_UTILS_SERVER_URL + XLSX_GET_SHEETS_PATH;
 		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executeMultipart(url, HttpMethod.POST, "file", filename, data);
 		return new JSONObject(response.getBody());
 	}
 
+
+	/**
+	 * Call Microsoft Utilities Service to extract data from xlsx file and return it in csv format
+	 *
+	 * @param filename expected filename
+	 * @param data xlsx file
+	 * @param sheetName name of xlsx sheet to read
+	 * @param sheetRange cell range on sheet (Ex: A1:D1 or A2:A10)
+	 * @param orientation portrait or landscape
+	 * @return response from msft utilities service with transformed data in csv format
+	 */
 	public String extractXlsxToCsv(String filename, byte[] data, String sheetName, String sheetRange, String orientation) {
 		String url = MICROSOFT_UTILS_SERVER_URL + XLSX_EXTRACT_CSV_PATH;
 		url = url.replace("{sheetName}", sheetName);
@@ -63,6 +96,16 @@ public class MicrosoftHelper extends AbstractHelper {
 		return response.getBody();
 	}
 
+	/**
+	 * Call Microsoft Utilities Service to extract data from xlsx file and return it in json format
+	 *
+	 * @param filename expected filename
+	 * @param data xlsx file
+	 * @param sheetName name of xlsx sheet to read
+	 * @param sheetRange cell range on sheet (Ex: A1:D1 or A2:A10)
+	 * @param orientation portrait or landscape
+	 * @return response from msft utilities service with transformed data in json format
+	 */
 	public JSONObject extractXlsxToJson(String filename, byte[] data, String sheetName, String sheetRange, String orientation) {
 		String url = MICROSOFT_UTILS_SERVER_URL + XLSX_EXTRACT_JSON_PATH;
 		url = url.replace("{sheetName}", sheetName);
@@ -75,6 +118,13 @@ public class MicrosoftHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Microsoft Utilities Service to extract text from docx file
+	 *
+	 * @param filename expected filename
+	 * @param data docx file
+	 * @return response from msft utilities service with text data from docx file
+	 */
 	public String extractDocxToTxt(String filename, byte[] data) {
 		String url = MICROSOFT_UTILS_SERVER_URL + DOCX_EXTRACT_PATH;
 		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executeMultipart(url, HttpMethod.POST, "file", filename, data);

--- a/src/main/java/gov/cdc/helper/OAuthHelper.java
+++ b/src/main/java/gov/cdc/helper/OAuthHelper.java
@@ -16,6 +16,12 @@ public class OAuthHelper extends AbstractHelper {
 	private static String REQUEST_TOKEN;
 	private static String SCOPES;
 
+	/**
+	 * OAuthHelper singleton constructor
+	 *
+	 * @return
+	 * @throws IOException
+	 */
 	public static OAuthHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -35,6 +41,14 @@ public class OAuthHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Get OAuth access token
+	 *
+	 * @see OAuthHelper#getToken(List)
+	 *
+	 * @return
+	 * @throws IOException
+	 */
 	public String getToken() throws IOException {
 		if (SCOPES != null && !SCOPES.isEmpty())
 			return getToken(Arrays.asList(SCOPES.split(" ")));
@@ -42,6 +56,13 @@ public class OAuthHelper extends AbstractHelper {
 			return getToken(null);
 	}
 
+	/**
+	 * Get OAuth access token
+	 *
+	 * @param scopes list of OAuth scopes
+	 * @return token
+	 * @throws IOException
+	 */
 	public String getToken(List<String> scopes) throws IOException {
 		String token;
 		String url = OAUTH_SERVER_URL + REQUEST_TOKEN;

--- a/src/main/java/gov/cdc/helper/ObjectHelper.java
+++ b/src/main/java/gov/cdc/helper/ObjectHelper.java
@@ -34,6 +34,15 @@ public class ObjectHelper extends AbstractHelper {
 	private static String DB;
 	private static String COLLECTION;
 
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of ObjectHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of ObjectHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static ObjectHelper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (ObjectHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -41,6 +50,11 @@ public class ObjectHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * ObjectHelper singleton constructor
+	 * @return
+	 * @throws IOException
+	 */
 	public static ObjectHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -71,10 +85,26 @@ public class ObjectHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Call Object Service to get object from database using database and collection defined in config-services.properties
+	 *
+	 * @see ObjectHelper#getObject(String, String, String)
+	 *
+	 * @param objectId object ID
+	 * @return response from Object Service containing object details
+	 */
 	public JSONObject getObject(String objectId) {
 		return getObject(objectId, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to get object from database
+	 *
+	 * @param objectId object ID
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from Object Service containing object details
+	 */
 	public JSONObject getObject(String objectId, String db, String collection) {
 		String url = OBJECT_SERVER_URL + GET_OBJECT_PATH;
 		url = url.replace("{db}", db);
@@ -94,10 +124,27 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(body);
 	}
 
+	/**
+	 * Returns true if object exists in database and collection defined in config-services.properties
+	 *
+	 * @see ObjectHelper#exists(String, String, String)
+	 *
+	 * @param objectId object ID
+	 * @return true if object exists
+	 */
 	public boolean exists(String objectId) {
 		return exists(objectId, DB, COLLECTION);
 	}
 
+
+	/**
+	 * Returns true if object exists
+	 *
+	 * @param objectId object ID
+	 * @param db database name
+	 * @param collection collection name
+	 * @return true if object exists
+	 */
 	public boolean exists(String objectId, String db, String collection) {
 		String url = OBJECT_SERVER_URL + GET_OBJECT_PATH;
 		url = url.replace("{db}", db);
@@ -114,10 +161,25 @@ public class ObjectHelper extends AbstractHelper {
 		return true;
 	}
 
+	/**
+	 * Call Object Service to bulk import objects using csv formatted data. Database and Collection values
+	 * defined in config-services.properties
+	 *
+	 * @see ObjectHelper#bulkImport(String, String, String)
+	 *
+	 * @param data csv formatted objects
+	 * @return response from object service
+	 */
 	public JSONObject bulkImport(String data) {
 		return bulkImport(data, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to bulk import objects using csv formatted data.
+	 *
+	 * @param data csv formatted objects
+	 * @return response from object service
+	 */
 	public JSONObject bulkImport(String data, String db, String collection) {
 		String url = OBJECT_SERVER_URL + BULK_IMPORT_PATH;
 		url = url.replace("{db}", db);
@@ -127,18 +189,60 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to create an object. Database and Collection values defined in config-services.properties
+	 *
+	 * @see ObjectHelper#createObject(JSONObject, String)
+	 * @see ObjectHelper#createObject(JSONObject, String, String)
+	 * @see ObjectHelper#createObject(JSONObject, String, String, String)
+	 *
+	 * @param json object data
+	 * @return response from object service with object details
+	 */
 	public JSONObject createObject(JSONObject json) {
 		return createObject(json, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to create an object.
+	 *
+	 * @see ObjectHelper#createObject(JSONObject)
+	 * @see ObjectHelper#createObject(JSONObject, String)
+	 * @see ObjectHelper#createObject(JSONObject, String, String, String)
+	 *
+	 * @param json object data
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with object details
+	 */
 	public JSONObject createObject(JSONObject json, String db, String collection) {
 		return createObject(json, "", db, collection);
 	}
 
+	/**
+	 * Call Object Service to create an object.
+	 *
+	 * @see ObjectHelper#createObject(JSONObject)
+	 * @see ObjectHelper#createObject(JSONObject, String, String)
+	 * @see ObjectHelper#createObject(JSONObject, String, String, String)
+	 *
+	 * @param json object data
+	 * @param id object id
+	 * @return response from object service with object details
+	 */
 	public JSONObject createObject(JSONObject json, String id) {
 		return createObject(json, id, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to create an object
+	 *
+	 * @param json object data
+	 * @param id object id
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with object details
+	 */
 	public JSONObject createObject(JSONObject json, String id, String db, String collection) {
 		String url = OBJECT_SERVER_URL + CREATE_OBJECT_PATH;
 		url = url.replace("{db}", db);
@@ -157,10 +261,27 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to count number of objects in a collection.
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#createObject(JSONObject, String, String)
+	 *
+	 * @param json search query
+	 * @return response from object service with number of objects matching query
+	 */
 	public JSONObject countObjects(JSONObject json) {
 		return countObjects(json, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to count number of objects in a collection.
+	 *
+	 * @param json search query
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with number of objects matching query
+	 */
 	public JSONObject countObjects(JSONObject json, String db, String collection) {
 		String url = OBJECT_SERVER_URL + COUNT_OBJECTS_PATH;
 		url = url.replace("{db}", db);
@@ -170,10 +291,26 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to return aggregate values in a collection
+	 *
+	 * @see ObjectHelper#aggregate(JSONArray, String, String)
+	 *
+	 * @param json search query
+	 * @return object service response containing aggregate values
+	 */
 	public JSONObject aggregate(JSONArray json) {
 		return aggregate(json, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to return aggregate values in a collection
+	 *
+	 * @param json search query
+	 * @param db database name
+	 * @param collection collection name
+	 * @return object service response containing aggregate values
+	 */
 	public JSONObject aggregate(JSONArray json, String db, String collection) {
 		String url = OBJECT_SERVER_URL + AGGREGATE_PATH;
 		url = url.replace("{db}", db);
@@ -183,10 +320,31 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to get distinct values for a specified field across a single collection.
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#distinct(JSONObject, String, String, String)
+	 *
+	 * @param json search query
+	 * @param field field name
+	 * @return response from object service with distinct values for specified field
+	 */
 	public JSONArray distinct(JSONObject json, String field) {
 		return distinct(json, field, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to get distinct values for a specified field across a single collection.
+	 *
+	 * @see ObjectHelper#distinct(JSONObject, String, String, String)
+	 *
+	 * @param json search query
+	 * @param field field name
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with distinct values for specified field
+	 */
 	public JSONArray distinct(JSONObject json, String field, String db, String collection) {
 		String url = OBJECT_SERVER_URL + DISTINCT_PATH;
 		url = url.replace("{db}", db);
@@ -197,14 +355,48 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONArray(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to find objects
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#find(JSONObject, String, String)
+	 * @see ObjectHelper#find(JSONObject, String, String, int, int)
+	 *
+	 * @param json search query
+	 * @return response from object service with matching objects
+	 */
 	public JSONObject find(JSONObject json) {
 		return find(json, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to find objects
+	 *
+	 * @see ObjectHelper#find(JSONObject)
+	 * @see ObjectHelper#find(JSONObject, String, String, int, int)
+	 *
+	 * @param json search query
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with matching objects
+	 */
 	public JSONObject find(JSONObject json, String db, String collection) {
 		return find(json, db, collection, -1, -1);
 	}
 
+	/**
+	 * Call Object Service to find objects
+	 *
+	 * @see ObjectHelper#find(JSONObject)
+	 * @see ObjectHelper#find(JSONObject, String, String)
+	 *
+	 * @param json search query
+	 * @param db database name
+	 * @param collection collection name
+	 * @param from starting point for result set
+	 * @param size limit number of objects to return
+	 * @return response from object service with matching objects
+	 */
 	public JSONObject find(JSONObject json, String db, String collection, int from, int size) {
 		String url = OBJECT_SERVER_URL + FIND_PATH;
 		url = url.replace("{db}", db);
@@ -224,14 +416,48 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to search objects in a specific collection using url parameters instead of json payload
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#search(String, String, String)
+	 * @see ObjectHelper#search(String, String, String, int, int)
+	 *
+	 * @param qs search query
+	 * @return response from object service with matching objects
+	 */
 	public JSONObject search(String qs) {
 		return search(qs, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to search objects in a specific collection using url parameters instead of json payload
+	 *
+	 * @see ObjectHelper#search(String)
+	 * @see ObjectHelper#search(String, String, String, int, int)
+	 *
+	 * @param qs search query
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with matching objects
+	 */
 	public JSONObject search(String qs, String db, String collection) {
 		return search(qs, db, collection, -1, -1);
 	}
 
+	/**
+	 * Call Object Service to search objects in a specific collection using url parameters instead of json payload
+	 *
+	 * @see ObjectHelper#search(String)
+	 * @see ObjectHelper#search(String, String, String)
+	 *
+	 * @param qs search query
+	 * @param db database name
+	 * @param collection collection name
+	 * @param from starting poi9nt of result set
+	 * @param size limit number of objects to return
+	 * @return response from object service with matching objects
+	 */
 	public JSONObject search(String qs, String db, String collection, int from, int size) {
 		String url = OBJECT_SERVER_URL + SEARCH_PATH;
 		url = url.replace("{qs}", qs);
@@ -252,10 +478,27 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to delete object
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#deleteObject(String, String, String)
+	 *
+	 * @param objectId object id
+	 * @return response from object service
+	 */
 	public JSONObject deleteObject(String objectId) {
 		return deleteObject(objectId, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to delete object
+	 *
+	 * @param objectId object id
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service
+	 */
 	public JSONObject deleteObject(String objectId, String db, String collection) {
 		String url = OBJECT_SERVER_URL + DELETE_OBJECT_PATH;
 		url = url.replace("{db}", db);

--- a/src/main/java/gov/cdc/helper/ObjectHelper.java
+++ b/src/main/java/gov/cdc/helper/ObjectHelper.java
@@ -113,12 +113,6 @@ public class ObjectHelper extends AbstractHelper {
 
 		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executeGet(url);
 
-		/* Removed so user will receive error from mongo
-		// Some micro services are storing a json object with $ and . in keys,
-		// but it's not supported
-		body = body.replaceAll("__DOLLAR__", "\\$");
-		body = body.replaceAll("__DOT__", "\\.");
-		*/
 		String body = response.getBody();
 
 		return new JSONObject(body);
@@ -249,12 +243,6 @@ public class ObjectHelper extends AbstractHelper {
 		url = url.replace("{collection}", collection);
 		url = url.replace("{id}", id);
 
-		/*Removed so user will receive error from mongo
-		// Some micro services are storing a json object with $ and . in keys,
-		// but it's not supported
-		payloadAsString = payloadAsString.replaceAll("\\$", "__DOLLAR__");
-		payloadAsString = payloadAsString.replaceAll("\\.", "__DOT__");
-		*/
 		String payloadAsString = json.toString();
 
 		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executePost(url, payloadAsString, MediaType.APPLICATION_JSON);
@@ -538,12 +526,6 @@ public class ObjectHelper extends AbstractHelper {
 		url = url.replace("{collection}", collection);
 		url = url.replace("{id}", objectId);
 
-		/*Removed so user will receive error from mongo
-		// Some micro services are storing a json object with $ and . in keys,
-		// but it's not supported
-		payloadAsString = payloadAsString.replaceAll("\\$", "__DOLLAR__");
-		payloadAsString = payloadAsString.replaceAll("\\.", "__DOT__");
-		*/
 		String payloadAsString = json.toString();
 
 		// But reapply the _id if it has been changed

--- a/src/main/java/gov/cdc/helper/ObjectHelper.java
+++ b/src/main/java/gov/cdc/helper/ObjectHelper.java
@@ -509,10 +509,29 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call object Service to update object
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#updateObject(String, JSONObject, String, String)
+	 *
+	 * @param objectId object id
+	 * @param command new object data
+	 * @return response from object service
+	 */
 	public JSONObject updateObject(String objectId, JSONObject command) {
 		return updateObject(objectId, command, DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to update object
+	 *
+	 * @param objectId object id
+	 * @param json new object data
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service
+	 */
 	public JSONObject updateObject(String objectId, JSONObject json, String db, String collection) {
 		String url = OBJECT_SERVER_URL + UPDATE_OBJECT_PATH;
 		url = url.replace("{db}", db);
@@ -538,10 +557,24 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Call Object Service to delete collection
+	 * Database and Collection values defined in config-services.properties.
+	 *
+	 * @see ObjectHelper#deleteCollection(String, String)
+	 * @return response from object service with success boolean
+	 */
 	public JSONObject deleteCollection() {
 		return deleteCollection(DB, COLLECTION);
 	}
 
+	/**
+	 * Call Object Service to delete collection
+	 *
+	 * @param db database name
+	 * @param collection collection name
+	 * @return response from object service with success boolean
+	 */
 	public JSONObject deleteCollection(String db, String collection) {
 		String url = OBJECT_SERVER_URL + DELETE_COLLECTION_PATH;
 		url = url.replace("{db}", db);
@@ -551,6 +584,13 @@ public class ObjectHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Merge JSONObjects
+	 *
+	 * @param o1 base object
+	 * @param o2 object to merge into o1
+	 * @return object with values from o2 merged into o1
+	 */
 	public JSONObject merge(JSONObject o1, JSONObject o2) {
 		JSONObject o = new JSONObject(o1.toString());
 

--- a/src/main/java/gov/cdc/helper/RequestHelper.java
+++ b/src/main/java/gov/cdc/helper/RequestHelper.java
@@ -257,7 +257,7 @@ public class RequestHelper extends AbstractHelper {
 	}
 
 	/**
-	 * Call multipart http method.
+	 * Call multipart HTTP method.
 	 *
 	 * @param url request url
 	 * @param method request method
@@ -284,7 +284,7 @@ public class RequestHelper extends AbstractHelper {
 	}
 
 	/**
-	 * Call multipart http method.
+	 * Call multipart HTTP method.
 	 *
 	 * @param url request url
 	 * @param method request method
@@ -311,7 +311,7 @@ public class RequestHelper extends AbstractHelper {
 	}
 
 	/**
-	 * Call multipart http method
+	 * Call multipart HTTP method
 	 *
 	 * @param url request url
 	 * @param method request method
@@ -339,7 +339,7 @@ public class RequestHelper extends AbstractHelper {
 	}
 
 	/**
-	 * Call http method to download binary at url
+	 * Call HTTP method to download binary at url
 	 *
 	 * @param url binary location
 	 * @param method request method
@@ -361,7 +361,7 @@ public class RequestHelper extends AbstractHelper {
 	}
 
 	/**
-	 * Stream data via http request
+	 * Stream data via HTTP request
 	 *
 	 * @param url request url
 	 * @param method request method

--- a/src/main/java/gov/cdc/helper/RequestHelper.java
+++ b/src/main/java/gov/cdc/helper/RequestHelper.java
@@ -28,10 +28,26 @@ public class RequestHelper extends AbstractHelper {
 
 	private static RequestHelper instance;
 
+	/**
+	 * Create RequestHelper object using Basic authentication
+	 *
+	 * @param username
+	 * @param password
+	 *
+	 * @return
+	 */
 	public static RequestHelper getInstance(String username, String password) {
 		return (RequestHelper) createNew().setAuthorizationHeader("Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()));
 	}
 
+	/**
+	 * If RequestHelper isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of RequestHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of RequestHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 */
 	public static RequestHelper getInstance(String authorizationHeader) {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (RequestHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -39,6 +55,11 @@ public class RequestHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * RequestHelper singleton constructor
+	 *
+	 * @return
+	 */
 	public static RequestHelper getInstance() {
 		if (instance == null) {
 			instance = createNew();
@@ -46,6 +67,11 @@ public class RequestHelper extends AbstractHelper {
 		return instance;
 	}
 
+	/**
+	 * RequestHelper constructor
+	 *
+	 * @return
+	 */
 	private static RequestHelper createNew() {
 		return new RequestHelper();
 	}
@@ -54,34 +80,94 @@ public class RequestHelper extends AbstractHelper {
 
 	private static final RestTemplate rt = new RestTemplate();
 
+	/**
+	 * Call HTTP GET on url
+	 *
+	 * @param url request url
+	 *
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeGet(String url) {
 		return execute(url, HttpMethod.GET, MediaType.APPLICATION_JSON, null);
 	}
 
+	/**
+	 * Call HTTP POST on url
+	 *
+	 * @param url request url
+	 *
+	 * @return http response
+	 */
 	public ResponseEntity<String> executePost(String url) {
 		return execute(url, HttpMethod.POST, MediaType.TEXT_PLAIN, null);
 	}
 
+	/**
+	 * Call HTTP POST
+	 *
+	 * @param url request url
+	 * @param data plain text payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executePost(String url, String data) {
 		return execute(url, HttpMethod.POST, MediaType.TEXT_PLAIN, data);
 	}
 
+	/**
+	 * Call HTTP POST
+	 *
+	 * @param url request url
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executePost(String url, MultiValueMap<String, String> data) {
 		return execute(url, HttpMethod.POST, data);
 	}
 
+	/**
+	 * Call HTTP POST
+	 *
+	 * @param url request url
+	 * @param data payload
+	 * @param mediaType payload media type (ex: application/json)
+	 * @return http response
+	 */
 	public ResponseEntity<String> executePost(String url, String data, MediaType mediaType) {
 		return execute(url, HttpMethod.POST, mediaType, data);
 	}
 
+	/**
+	 * Call HTTP PUT
+	 *
+	 * @param url request url
+	 * @param data plain text payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executePut(String url, String data) {
 		return execute(url, HttpMethod.PUT, MediaType.TEXT_PLAIN, data);
 	}
 
+	/**
+	 * Call HTTP PUT
+	 *
+	 * @param url request url
+	 * @param data payload
+	 * @param mediaType payload media type (ex: application/json)
+	 * @return http response
+	 */
 	public ResponseEntity<String> executePut(String url, String data, MediaType mediaType) {
 		return execute(url, HttpMethod.PUT, mediaType, data);
 	}
 
+	/**
+	 * Make HTTP call using provided method
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param contentType payload media type (ex: application/json)
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> execute(String url, HttpMethod method, MediaType contentType, String data) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -96,6 +182,14 @@ public class RequestHelper extends AbstractHelper {
 		return rt.exchange(url, method, request, String.class);
 	}
 
+	/**
+	 * Make HTTP call using provided method
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> execute(String url, HttpMethod method, MultiValueMap<String, String> data) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -109,22 +203,69 @@ public class RequestHelper extends AbstractHelper {
 		return rt.exchange(url, method, request, String.class);
 	}
 
+	/**
+	 * Call multipart HTTP POST
+	 *
+	 * @param url request url
+	 * @param fieldName form field name
+	 * @param filename expected file name
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeMultipartPost(String url, String fieldName, String filename, byte[] data) {
 		return executeMultipart(url, HttpMethod.POST, fieldName, filename, data);
 	}
 
+	/**
+	 * Call multipart HTTP POST
+	 *
+	 * @param url request url
+	 * @param fieldName form field name
+	 * @param filename expected file name
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeMultipartPost(String url, String fieldName, String filename, String data) {
 		return executeMultipart(url, HttpMethod.POST, fieldName, filename, data);
 	}
 
+	/**
+	 * Call multipart HTTP PUT
+	 *
+	 * @param url request url
+	 * @param fieldName form field name
+	 * @param filename expected file name
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeMultipartPut(String url, String fieldName, String filename, String data) {
 		return executeMultipart(url, HttpMethod.PUT, fieldName, filename, data);
 	}
 
+	/**
+	 * Call multipart HTTP method
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param fieldName form field name
+	 * @param filename expected file name
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeMultipart(String url, HttpMethod method, String fieldName, String filename, String data) {
 		return executeMultipart(url, method, fieldName, filename, data.getBytes());
 	}
 
+	/**
+	 * Call multipart http method.
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param fieldName form field name
+	 * @param filename expected file name
+	 * @param data payload
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeMultipart(String url, HttpMethod method, String fieldName, String filename, byte[] data) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -142,6 +283,16 @@ public class RequestHelper extends AbstractHelper {
 		return rt.exchange(url, method, request, String.class);
 	}
 
+	/**
+	 * Call multipart http method.
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param fieldName form field name
+	 * @param filename expected file name
+	 * @param data payload
+	 * @return http response containing byte stream
+	 */
 	public ResponseEntity<byte[]> executeMultipartAndGetBytes(String url, HttpMethod method, String fieldName, String filename, byte[] data) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -159,6 +310,15 @@ public class RequestHelper extends AbstractHelper {
 		return rt.exchange(url, method, request, byte[].class);
 	}
 
+	/**
+	 * Call multipart http method
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param fieldName expected file name
+	 * @param resources list of payloads
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeMultipart(String url, HttpMethod method, String fieldName, List<FileMessageResource> resources) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -178,6 +338,13 @@ public class RequestHelper extends AbstractHelper {
 		return rt.exchange(url, method, request, String.class);
 	}
 
+	/**
+	 * Call http method to download binary at url
+	 *
+	 * @param url binary location
+	 * @param method request method
+	 * @return http response containing byte stream
+	 */
 	public ResponseEntity<byte[]> downloadBinary(String url, HttpMethod method) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -193,6 +360,13 @@ public class RequestHelper extends AbstractHelper {
 		return rt.exchange(url, method, entity, byte[].class);
 	}
 
+	/**
+	 * Stream data via http request
+	 *
+	 * @param url request url
+	 * @param method request method
+	 * @param processor
+	 */
 	public void stream(String url, HttpMethod method, StreamProcessor processor) {
 		logger.debug("URL: " + url);
 		logger.debug("Method: " + method);
@@ -208,6 +382,12 @@ public class RequestHelper extends AbstractHelper {
 		rt.execute(url, method, requestCallback, extractor);
 	}
 
+	/**
+	 * Call HTTP DELETE
+	 *
+	 * @param url request url
+	 * @return http response
+	 */
 	public ResponseEntity<String> executeDelete(String url) {
 		return execute(url, HttpMethod.DELETE, MediaType.TEXT_PLAIN, null);
 	}
@@ -223,6 +403,12 @@ public class RequestHelper extends AbstractHelper {
 			this.responseType = responseType;
 		}
 
+		/**
+		 * Sets accept headers for request for all supported media types
+		 *
+		 * @param request http request
+		 * @throws IOException
+		 */
 		@SuppressWarnings("unchecked")
 		public void doWithRequest(ClientHttpRequest request) throws IOException {
 			if (responseType != null) {
@@ -275,6 +461,12 @@ public class RequestHelper extends AbstractHelper {
 			}
 		}
 
+		/**
+		 * Write requestEntity body to request stream
+		 *
+		 * @param httpRequest
+		 * @throws IOException
+		 */
 		@Override
 		@SuppressWarnings("unchecked")
 		public void doWithRequest(ClientHttpRequest httpRequest) throws IOException {

--- a/src/main/java/gov/cdc/helper/ResourceHelper.java
+++ b/src/main/java/gov/cdc/helper/ResourceHelper.java
@@ -44,6 +44,12 @@ public class ResourceHelper {
 		throw new IllegalAccessError("Helper class");
 	}
 
+	/**
+	 * Returns default properties file
+	 *
+	 * @return default properties file
+	 * @throws IOException
+	 */
 	public static Properties getProperties() throws IOException {
 		if (properties == null) {
 			properties = new Properties();
@@ -60,12 +66,25 @@ public class ResourceHelper {
 		return properties;
 	}
 
+	/**
+	 * Returns properties from specified path
+	 *
+	 * @param path path to properties file
+	 * @return properties from path
+	 * @throws IOException
+	 */
 	public static Properties getProperties(String path) throws IOException {
 		Properties properties = new Properties();
 		properties.load(ResourceHelper.class.getResourceAsStream(path));
 		return properties;
 	}
 
+	/**
+	 * Return properties from specified path as a map
+	 *
+	 * @param path path to properties file
+	 * @return transformed properties
+	 */
 	public static Map<String, String> getPropertyMap(String path) {
 		Map<String, String> map = new HashMap<String, String>();
 		try {
@@ -79,10 +98,25 @@ public class ResourceHelper {
 		return map;
 	}
 
+	/**
+	 * Returns property value
+	 *
+	 * @param propertyName name of property
+	 * @return value of property
+	 * @throws IOException
+	 */
 	public static String getProperty(String propertyName) throws IOException {
 		return getProperties().getProperty(propertyName);
 	}
 
+	/**
+	 * Returns system environment property
+	 *
+	 * @param propertyName name of property
+	 * @param required whether or not an exception should be thrown if property value is empty
+	 * @return
+	 * @throws IOException
+	 */
 	public static String getSysEnvProperty(String propertyName, boolean required) throws IOException {
 		String value = System.getProperty(propertyName);
 		if (value == null || value.isEmpty())

--- a/src/main/java/gov/cdc/helper/ScopesHelper.java
+++ b/src/main/java/gov/cdc/helper/ScopesHelper.java
@@ -14,6 +14,12 @@ public class ScopesHelper extends AbstractHelper {
 	private static String SCOPES_SERVER_URL;
 	private static String GET_SCOPES_PATH;
 
+	/**
+	 * ScopesHelper constructor
+	 *
+	 * @return
+	 * @throws IOException
+	 */
 	public static ScopesHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -32,6 +38,12 @@ public class ScopesHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Call Scopes Service to get scopes for provided groups
+	 *
+	 * @param groupNames groups to get scopes for
+	 * @return response from Scopes Service
+	 */
 	public JSONObject getScopes(List<String> groupNames) {
 
 		String url = SCOPES_SERVER_URL + GET_SCOPES_PATH;

--- a/src/main/java/gov/cdc/helper/StorageHelper.java
+++ b/src/main/java/gov/cdc/helper/StorageHelper.java
@@ -26,6 +26,15 @@ public class StorageHelper extends AbstractHelper {
 	private static String COPY_NODE_PATH;
 	private static String DRAWER_NAME;
 
+	/**
+	 * If authorizationHeader isn't null and if provided header starts with 'Bearer',
+	 * constructs new instance of StorageHelper class and sets the authorization header to the provided value.
+	 * If authorizationHeader is null or doesn't start with 'Bearer', returns singleton instance of StorageHelper.
+	 *
+	 * @param authorizationHeader
+	 * @return
+	 * @throws IOException
+	 */
 	public static StorageHelper getInstance(String authorizationHeader) throws IOException {
 		if (authorizationHeader != null && (authorizationHeader.startsWith("Bearer") || authorizationHeader.startsWith("bearer")))
 			return (StorageHelper) createNew().setAuthorizationHeader(authorizationHeader);
@@ -33,6 +42,11 @@ public class StorageHelper extends AbstractHelper {
 			return getInstance();
 	}
 
+	/**
+	 * StorageHelper singleton constructor
+	 * @return
+	 * @throws IOException
+	 */
 	public static StorageHelper getInstance() throws IOException {
 		if (instance == null) {
 			instance = createNew();
@@ -62,10 +76,21 @@ public class StorageHelper extends AbstractHelper {
 		return helper;
 	}
 
+	/**
+	 * Returns true if drawer defined in config-services.properties exists
+	 *
+	 * @return true if drawer defined in config-services.properties exists
+	 */
 	public boolean exists() {
 		return exists(DRAWER_NAME);
 	}
 
+	/**
+	 * Returns true if drawer exists
+	 *
+	 * @param name drawer name
+	 * @return true if drawer exists
+	 */
 	public boolean exists(String name) {
 		boolean exists = false;
 		JSONArray arr = getDrawers();
@@ -75,16 +100,32 @@ public class StorageHelper extends AbstractHelper {
 		return exists;
 	}
 
+	/**
+	 * Get all drawers from Storage Service
+	 *
+	 * @return all drawers from storage service
+	 */
 	public JSONArray getDrawers() {
 		String url = STORAGE_SERVER_URL + GET_DRAWERS_PATH;
 		ResponseEntity<String> response = RequestHelper.getInstance(getAuthorizationHeader()).executeGet(url);
 		return new JSONArray(response.getBody());
 	}
 
+	/**
+	 * Create drawer defined in config-services.properties
+	 *
+	 * @return http response from storage service
+	 */
 	public JSONObject createDrawer() {
 		return createDrawer(DRAWER_NAME);
 	}
 
+	/**
+	 * Create drawer
+	 *
+	 * @param name drawer name
+	 * @return http response from storage service
+	 */
 	public JSONObject createDrawer(String name) {
 		String url = STORAGE_SERVER_URL + CREATE_DRAWER_PATH;
 		url = url.replace("{name}", name);
@@ -93,10 +134,21 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Delete drawer defined in config-services.properties
+	 *
+	 * @return http response from storage service
+	 */
 	public JSONObject deleteDrawer() {
 		return deleteDrawer(DRAWER_NAME);
 	}
 
+	/**
+	 * Delete drawer
+	 *
+	 * @param name drawer name
+	 * @return http response from storage service
+	 */
 	public JSONObject deleteDrawer(String name) {
 		String url = STORAGE_SERVER_URL + DELETE_DRAWER_PATH;
 		url = url.replace("{name}", name);
@@ -105,10 +157,21 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Get drawer defined in config-services.properties
+	 *
+	 * @return drawer data from storage service
+	 */
 	public JSONObject getDrawer() {
 		return getDrawer(DRAWER_NAME);
 	}
 
+	/**
+	 * Get drawer from storage service
+	 *
+	 * @param name drawer name
+	 * @return drawer data from storage service
+	 */
 	public JSONObject getDrawer(String name) {
 		String url = STORAGE_SERVER_URL + GET_DRAWER_PATH;
 		url = url.replace("{name}", name);
@@ -117,14 +180,32 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * List all nodes in drawer defined in config-services.properties
+	 *
+	 * @return http response from storage service with all nodes in drawer
+	 */
 	public JSONArray listNodes() {
 		return listNodes(DRAWER_NAME, "");
 	}
 
+	/**
+	 * List all nodes in drawer defined in config-services.properties
+	 *
+	 * @param prefix limit response to keys that begin with this prefix
+	 * @return http response from storage service with all nodes beginning with prefix
+	 */
 	public JSONArray listNodes(String prefix) {
 		return listNodes(DRAWER_NAME, prefix);
 	}
 
+	/**
+	 * List all nodes in drawer
+	 *
+	 * @param name drawer name
+	 * @param prefix limit response to keys that begin with this prefix
+	 * @return http response from storage service with all nodes beginning with prefix
+	 */
 	public JSONArray listNodes(String name, String prefix) {
 		String url = STORAGE_SERVER_URL + LIST_NODES_PATH;
 		url = url.replace("{name}", name);
@@ -137,26 +218,86 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONArray(response.getBody());
 	}
 
+	/**
+	 * Create node defined in config-service.properties
+	 *
+	 * @param filename node id
+	 * @param data payload
+	 * @param generateStruct generate date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String filename, byte[] data, boolean generateStruct, boolean generateId) {
 		return createNode(DRAWER_NAME, filename, data, generateStruct, generateId, false);
 	}
 
+	/**
+	 * Create node defined in config-service.properties
+	 *
+	 * @param filename node id
+	 * @param data payload
+	 * @param generateStruct generate date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String filename, String data, boolean generateStruct, boolean generateId) {
 		return createNode(DRAWER_NAME, filename, data, generateStruct, generateId);
 	}
 
+	/**
+	 * Create node defined in config-service.properties
+	 *
+	 * @param filename node id
+	 * @param data payload
+	 * @param generateStruct generate date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @param replace replace if existing
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String filename, String data, boolean generateStruct, boolean generateId, boolean replace) {
 		return createNode(DRAWER_NAME, filename, data, generateStruct, generateId, replace);
 	}
 
+	/**
+	 * Create node
+	 *
+	 * @param drawerName  drawer name
+	 * @param filename node id
+	 * @param data payload
+	 * @param generateStruct date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String drawerName, String filename, String data, boolean generateStruct, boolean generateId) {
 		return createNode(drawerName, filename, data.getBytes(), generateStruct, generateId, false);
 	}
 
+	/**
+	 * Create node
+	 *
+	 * @param drawerName  drawer name
+	 * @param filename node id
+	 * @param data payload
+	 * @param generateStruct date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @param replace replace if existing
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String drawerName, String filename, String data, boolean generateStruct, boolean generateId, boolean replace) {
 		return createNode(drawerName, filename, data.getBytes(), generateStruct, generateId, replace);
 	}
 
+	/**
+	 * Create node
+	 *
+	 * @param drawerName  drawer name
+	 * @param filename node id
+	 * @param data payload
+	 * @param generateStruct date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @param replace replace if existing
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String drawerName, String filename, byte[] data, boolean generateStruct, boolean generateId, boolean replace) {
 		String url = STORAGE_SERVER_URL + CREATE_NODE_PATH;
 		url = url.replace("{name}", drawerName);
@@ -172,14 +313,37 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Create node with generated date/time structure and generated id
+	 *
+	 * @param filename node id
+	 * @param data payload
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String filename, String data) {
 		return createNode(filename, data, true, true);
 	}
 
+	/**
+	 * Create node with generated date/time structure and generated id
+	 *
+	 * @param drawerName drawer name
+	 * @param filename node id
+	 * @param data payload
+	 * @return http response from storage service with details of created node
+	 */
 	public JSONObject createNode(String drawerName, String filename, String data) {
 		return createNode(drawerName, filename, data, true, true);
 	}
 
+	/**
+	 * Update node
+	 *
+	 * @param drawerName drawer name
+	 * @param nodeId node id
+	 * @param data payload
+	 * @return http response from storage service with success boolean
+	 */
 	public JSONObject updateNode(String drawerName, String nodeId, String data) {
 		String url = STORAGE_SERVER_URL + UPDATE_NODE_PATH;
 		url = url.replace("{name}", drawerName);
@@ -189,10 +353,23 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Delete node defined in config-services.properties
+	 *
+	 * @param nodeId node id
+	 * @return http response from storage service with success boolean
+	 */
 	public JSONObject deleteNode(String nodeId) {
 		return deleteNode(DRAWER_NAME, nodeId);
 	}
 
+	/**
+	 * Delete node
+	 *
+	 * @param drawerName drawer name
+	 * @param nodeId node id
+	 * @return http response from storage service with success boolean
+	 */
 	public JSONObject deleteNode(String drawerName, String nodeId) {
 		String url = STORAGE_SERVER_URL + DELETE_NODE_PATH;
 		url = url.replace("{name}", drawerName);
@@ -202,10 +379,23 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Get node defined in config-services.properties
+	 *
+	 * @param nodeId node id
+	 * @return http response from storage service with node details
+	 */
 	public JSONObject getNode(String nodeId) {
 		return getNode(DRAWER_NAME, nodeId);
 	}
 
+	/**
+	 * Get node from storage service
+	 *
+	 * @param drawerName drawer name
+	 * @param nodeId node id
+	 * @return http response from storage service with node details
+	 */
 	public JSONObject getNode(String drawerName, String nodeId) {
 		String url = STORAGE_SERVER_URL + GET_NODE_PATH;
 		url = url.replace("{name}", drawerName);
@@ -215,6 +405,13 @@ public class StorageHelper extends AbstractHelper {
 		return new JSONObject(response.getBody());
 	}
 
+	/**
+	 * Download node from storage service
+	 *
+	 * @param drawerName drawer name
+	 * @param nodeId node id
+	 * @return node from storage service
+	 */
 	public byte[] dowloadNode(String drawerName, String nodeId) {
 		String url = STORAGE_SERVER_URL + DOWNLOAD_NODE_PATH;
 		url = url.replace("{name}", drawerName);
@@ -224,10 +421,22 @@ public class StorageHelper extends AbstractHelper {
 		return response.getBody();
 	}
 
-	public byte[] dowloadNode(String nodeId) {
+	/**
+	 * Download node from storage service defined in config-services.properties
+	 *
+	 * @param nodeId node id
+	 * @return node from storage service
+	 */
+	public byte[] downloadNode(String nodeId) {
 		return dowloadNode(DRAWER_NAME, nodeId);
 	}
 
+	/**
+	 * Stream node defined in config-services.properties
+	 *
+	 * @param nodeId node id
+	 * @param processor
+	 */
 	public void streamNode(String nodeId, StreamProcessor processor) {
 		String url = STORAGE_SERVER_URL + DOWNLOAD_NODE_PATH;
 		url = url.replace("{name}", DRAWER_NAME);
@@ -236,10 +445,31 @@ public class StorageHelper extends AbstractHelper {
 		RequestHelper.getInstance(getAuthorizationHeader()).stream(url, HttpMethod.GET, processor);
 	}
 
+	/**
+	 * Copy node defined in config-services.properties
+	 *
+	 * @param nodeId node id
+	 * @param targetDrawerName target drawer name
+	 * @param generateStruct generate date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @param deleteOriginal delete original
+	 * @return http response from storage service with success boolean
+	 */
 	public JSONObject copyNode(String nodeId, String targetDrawerName, boolean generateStruct, boolean generateId, boolean deleteOriginal) {
 		return copyNode(DRAWER_NAME, nodeId, targetDrawerName, generateStruct, generateId, deleteOriginal);
 	}
 
+	/**
+	 * Copy node
+	 *
+	 * @param drawerName drawer name
+	 * @param nodeId node id
+	 * @param targetDrawerName target drawer name
+	 * @param generateStruct generate date/time structure if asked
+	 * @param generateId generate node id if asked
+	 * @param deleteOriginal delete original
+	 * @return http response from storage service with success boolean
+	 */
 	public JSONObject copyNode(String drawerName, String nodeId, String targetDrawerName, boolean generateStruct, boolean generateId, boolean deleteOriginal) {
 		String url = STORAGE_SERVER_URL + COPY_NODE_PATH;
 		url = url.replace("{source}", drawerName);

--- a/src/main/java/gov/cdc/helper/common/FileMessageResource.java
+++ b/src/main/java/gov/cdc/helper/common/FileMessageResource.java
@@ -26,6 +26,7 @@ public class FileMessageResource extends ByteArrayResource {
 
 	/**
 	 * Returns filename associated with the {@Link MimeMessage} in the form data
+	 *
 	 * @return filename associated with the {@Link MimeMessage} in the form data
 	 */
 	@Override

--- a/src/main/java/gov/cdc/helper/common/FileMessageResource.java
+++ b/src/main/java/gov/cdc/helper/common/FileMessageResource.java
@@ -24,11 +24,19 @@ public class FileMessageResource extends ByteArrayResource {
 		this.filename = filename;
 	}
 
+	/**
+	 * Returns filename associated with the {@Link MimeMessage} in the form data
+	 * @return filename associated with the {@Link MimeMessage} in the form data
+	 */
 	@Override
 	public String getFilename() {
 		return filename;
 	}
 
+	/**
+	 * @param obj
+	 * @return true if obj is FileMessageResource with equal filename (ignoring case) or true if obj is ByteArrayResource with equal byteArray
+	 */
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof FileMessageResource) {
@@ -38,6 +46,9 @@ public class FileMessageResource extends ByteArrayResource {
 			return super.equals(obj);
 	}
 
+	/**
+	 * @return a hash code value for this object
+	 */
 	@Override
 	public int hashCode() {
 		return super.hashCode() + getFilename().hashCode();

--- a/src/main/java/gov/cdc/helper/common/ServiceException.java
+++ b/src/main/java/gov/cdc/helper/common/ServiceException.java
@@ -9,20 +9,37 @@ public class ServiceException extends Exception {
 
 	private final String obj;
 
+	/**
+	 *  Constructs a ServiceException with provided message
+	 * @param message string describing exception
+	 */
 	public ServiceException(String message) {
 		super(message);
 		obj = null;
 	}
 
+	/**
+	 * Constructs a ServiceException with provided exception
+	 * @param e exception to be wrapped by ServiceException
+	 */
 	public ServiceException(Exception e) {
 		super(e);
 		obj = null;
 	}
 
+	/**
+	 * Constructs ServiceException with provided JSONObject
+	 * @param obj exception details
+	 */
 	public ServiceException(JSONObject obj) {
 		this.obj = obj.toString();
 	}
 
+	/**
+	 * Returns ServiceException details if the ServiceException was created with a JSONObjeclt
+	 * @return JSONObject details of ServiceException if it was created with JSONObject. Otherwise returns null
+	 * @throws JSONException
+	 */
 	public JSONObject getObj() throws JSONException {
 		return obj != null ? new JSONObject(obj) : null;
 	}

--- a/src/main/java/gov/cdc/helper/common/ServiceException.java
+++ b/src/main/java/gov/cdc/helper/common/ServiceException.java
@@ -10,7 +10,8 @@ public class ServiceException extends Exception {
 	private final String obj;
 
 	/**
-	 *  Constructs a ServiceException with provided message
+	 * Constructs a new ServiceException with the specified message
+	 *
 	 * @param message string describing exception
 	 */
 	public ServiceException(String message) {
@@ -19,7 +20,8 @@ public class ServiceException extends Exception {
 	}
 
 	/**
-	 * Constructs a ServiceException with provided exception
+	 * Constructs a new ServiceException with the specified exception
+	 *
 	 * @param e exception to be wrapped by ServiceException
 	 */
 	public ServiceException(Exception e) {
@@ -28,7 +30,8 @@ public class ServiceException extends Exception {
 	}
 
 	/**
-	 * Constructs ServiceException with provided JSONObject
+	 * Constructs a new ServiceException with the specified JSONObject
+	 *
 	 * @param obj exception details
 	 */
 	public ServiceException(JSONObject obj) {
@@ -36,7 +39,8 @@ public class ServiceException extends Exception {
 	}
 
 	/**
-	 * Returns ServiceException details if the ServiceException was created with a JSONObjeclt
+	 * Returns ServiceException details if the ServiceException was created with a JSONObject
+	 *
 	 * @return JSONObject details of ServiceException if it was created with JSONObject. Otherwise returns null
 	 * @throws JSONException
 	 */

--- a/src/main/java/gov/cdc/helper/common/StringResponseExtractor.java
+++ b/src/main/java/gov/cdc/helper/common/StringResponseExtractor.java
@@ -17,6 +17,7 @@ public class StringResponseExtractor implements ResponseExtractor<String> {
 
 	/**
 	 * Constructs a new instance of the StringResponseExtractor class
+	 *
 	 * @param processor
 	 */
 	public StringResponseExtractor(StreamProcessor processor) {
@@ -25,6 +26,7 @@ public class StringResponseExtractor implements ResponseExtractor<String> {
 
 	/**
 	 * Reads response body into processor and returns null
+	 *
 	 * @param response client response to http request
 	 * @return null
 	 * @throws IOException

--- a/src/main/java/gov/cdc/helper/common/StringResponseExtractor.java
+++ b/src/main/java/gov/cdc/helper/common/StringResponseExtractor.java
@@ -14,11 +14,21 @@ public class StringResponseExtractor implements ResponseExtractor<String> {
 	private static final Logger logger = Logger.getLogger(StringResponseExtractor.class);
 	
 	private StreamProcessor processor;
-	
+
+	/**
+	 * Constructs a new instance of the StringResponseExtractor class
+	 * @param processor
+	 */
 	public StringResponseExtractor(StreamProcessor processor) {
 		this.processor = processor;
 	}
 
+	/**
+	 * Reads response body into processor and returns null
+	 * @param response client response to http request
+	 * @return null
+	 * @throws IOException
+	 */
 	public String extractData(ClientHttpResponse response) throws IOException {
 		InputStream is = response.getBody();
 		BufferedReader reader = new BufferedReader(new InputStreamReader(is));

--- a/src/main/java/gov/cdc/security/SSLCertificateValidation.java
+++ b/src/main/java/gov/cdc/security/SSLCertificateValidation.java
@@ -15,7 +15,10 @@ import org.apache.log4j.Logger;
 public class SSLCertificateValidation {
 	
 	private static final Logger logger = Logger.getLogger(SSLCertificateValidation.class);
-	
+
+    /**
+     * Disable SSL Certificate Validation
+     */
 	public static void disable() {
         try {
             SSLContext sslc = SSLContext.getInstance("TLS");


### PR DESCRIPTION
Maven javadoc plugin can generate javadocs required for maven central 
generate with: mvn clean install

javadocs created in target/apidocs and target/fdns-java-sdk-1.0.4-javadoc.jar

doclint configuration added to handle java 8 warnings